### PR TITLE
Correct spelling of setQueryMetricResponseFactory

### DIFF
--- a/service/src/main/java/datawave/microservice/querymetric/config/QueryMetricHandlerConfiguration.java
+++ b/service/src/main/java/datawave/microservice/querymetric/config/QueryMetricHandlerConfiguration.java
@@ -126,7 +126,7 @@ public class QueryMetricHandlerConfiguration {
     public QueryGeometryHandler geometryHandler(QueryMetricHandlerProperties queryMetricHandlerProperties,
                     QueryMetricResponseFactory queryMetricResponseFactory) {
         QueryGeometryHandler handler = new SimpleQueryGeometryHandler(queryMetricHandlerProperties);
-        handler.setQueryetricResponseFactory(queryMetricResponseFactory);
+        handler.setQueryMetricResponseFactory(queryMetricResponseFactory);
         return handler;
     }
     

--- a/service/src/main/java/datawave/microservice/querymetric/handler/QueryGeometryHandler.java
+++ b/service/src/main/java/datawave/microservice/querymetric/handler/QueryGeometryHandler.java
@@ -10,5 +10,5 @@ public interface QueryGeometryHandler {
     
     QueryGeometryResponse getQueryGeometryResponse(String id, List<? extends BaseQueryMetric> queries);
     
-    void setQueryetricResponseFactory(QueryMetricResponseFactory queryMetricResponseFactory);
+    void setQueryMetricResponseFactory(QueryMetricResponseFactory queryMetricResponseFactory);
 }

--- a/service/src/main/java/datawave/microservice/querymetric/handler/SimpleQueryGeometryHandler.java
+++ b/service/src/main/java/datawave/microservice/querymetric/handler/SimpleQueryGeometryHandler.java
@@ -92,7 +92,7 @@ public class SimpleQueryGeometryHandler implements QueryGeometryHandler {
     }
     
     @Override
-    public void setQueryetricResponseFactory(QueryMetricResponseFactory queryMetricResponseFactory) {
+    public void setQueryMetricResponseFactory(QueryMetricResponseFactory queryMetricResponseFactory) {
         this.queryMetricResponseFactory = queryMetricResponseFactory;
     }
 }

--- a/service/src/test/java/datawave/microservice/querymetric/handler/SimpleQueryGeometryHandlerTest.java
+++ b/service/src/test/java/datawave/microservice/querymetric/handler/SimpleQueryGeometryHandlerTest.java
@@ -33,7 +33,7 @@ public class SimpleQueryGeometryHandlerTest {
     @BeforeEach
     public void setup() {
         handler = new SimpleQueryGeometryHandler(new QueryMetricHandlerProperties());
-        handler.setQueryetricResponseFactory(new QueryMetricResponseFactory(null, null));
+        handler.setQueryMetricResponseFactory(new QueryMetricResponseFactory(null, null));
         commonId = "super-special-query-id";
         
         luceneParams = new HashSet<>();


### PR DESCRIPTION
Fixes places where `setQueryMetricResponseFactory` was misspelled.