### PR TITLE
Fixes Intermittent Test Failures in QueryMetricOperationsHazelcastWriteBehindTest

### DIFF
--- a/service/src/test/java/datawave/microservice/querymetric/QueryMetricTestBase.java
+++ b/service/src/test/java/datawave/microservice/querymetric/QueryMetricTestBase.java
@@ -536,7 +536,7 @@ public class QueryMetricTestBase {
         MapStoreConfig mapStoreConfig = config.getMapConfig(incomingCache.getName()).getMapStoreConfig();
         int writeDelaySeconds = Math.min(mapStoreConfig.getWriteDelaySeconds(), 1000);
         boolean found = false;
-        while (!found && System.currentTimeMillis() < (now + (1000 * (writeDelaySeconds + 1)))) {
+        while (!found && System.currentTimeMillis() < (now + (1000 * (writeDelaySeconds + 1.5)))) {
             found = lastWrittenCache.get(queryId, QueryMetricUpdateHolder.class) != null;
             if (!found) {
                 try {


### PR DESCRIPTION
Closes #22 

This change increases the wait time during the check of whether or not the data has been written. The timing seemed to be off previously, which would cause an NPE to occur in ```QueryMetricOperationsHazelcastWriteBehindTest.MultipleMetricsStoredCorrectlyInCachesAndAccumulo```

Before I added my changes, the test failed 17/50 times.
After my changes, the test failed 0/50 times.