### PR TITLE
Add catch all error code for metrics

### DIFF
--- a/api/src/main/java/datawave/microservice/querymetric/BaseQueryMetric.java
+++ b/api/src/main/java/datawave/microservice/querymetric/BaseQueryMetric.java
@@ -944,6 +944,8 @@ public abstract class BaseQueryMetric implements HasMarkings, Serializable {
             this.setErrorCode(qe.getErrorCode());
             this.setErrorMessage(qe.getMessage());
         } else {
+            // '500-1' signifies an 'Unknown server error'. This serves as a catch-all error code.
+            this.setErrorCode("500-1");
             this.setErrorMessage(t.getCause() != null ? t.getCause().getMessage() : t.getMessage());
         }
     }

--- a/api/src/main/java/datawave/microservice/querymetric/BaseQueryMetric.java
+++ b/api/src/main/java/datawave/microservice/querymetric/BaseQueryMetric.java
@@ -940,18 +940,18 @@ public abstract class BaseQueryMetric implements HasMarkings, Serializable {
     }
     
     /**
-     * Sets the error code and error message of the metric. There are a few cases that can occur:
-     * <ul>
-     * <li>The throwable cause <u>IS</u> an instance of {@link QueryException}:</li>
+     * Sets the error code and error message of the metric. There are a few cases that can occur: <br>
+     * <br>
+     * <u>The throwable cause <b>IS</b> an instance of {@link QueryException}:</u>
      * <ul>
      * <li>In this case, the error message and error code will be set to the values that were passed when the exception was thrown.</li>
      * <li>If the error code happens to be blank, {@link BaseQueryMetric#DEFAULT_ERROR_CODE} will be used.</li>
      * </ul>
-     * <li>The throwable cause <u>IS NOT</u> an instance of {@link QueryException}:</li>
+     * <br>
+     * <u>The throwable cause <b>IS NOT</b> an instance of {@link QueryException}:</u>
      * <ul>
      * <li>In this case, there is no error code given by the exception, so the error code will be set to {@link BaseQueryMetric#DEFAULT_ERROR_CODE}.</li>
      * <li>The error message is set to the message passed by either the cause of the throwable (if it is not null) or the throwable itself.</li>
-     * </ul>
      * </ul>
      * <em>All possible error codes can be found here {@link datawave.webservice.query.exception.DatawaveErrorCode}.</em>
      *

--- a/api/src/test/java/datawave/microservice/querymetric/QueryMetricTest.java
+++ b/api/src/test/java/datawave/microservice/querymetric/QueryMetricTest.java
@@ -46,6 +46,7 @@ public class QueryMetricTest {
     private static ArrayList<PageMetric> pageTimes = null;
     private static List<String> positiveSelectors = null;
     private static List<String> proxyServers = null;
+    private static final String DEFAULT_ERROR_CODE = "500-1";
     
     @BeforeAll
     public static void setup() {
@@ -78,7 +79,7 @@ public class QueryMetricTest {
         Throwable t = new Throwable("non-datawave error");
         queryMetric.setError(t);
         assertEquals("non-datawave error", queryMetric.getErrorMessage());
-        assertEquals("500-1", queryMetric.getErrorCode());
+        assertEquals(DEFAULT_ERROR_CODE, queryMetric.getErrorCode());
     }
     
     @Test

--- a/api/src/test/java/datawave/microservice/querymetric/QueryMetricTest.java
+++ b/api/src/test/java/datawave/microservice/querymetric/QueryMetricTest.java
@@ -1,5 +1,6 @@
 package datawave.microservice.querymetric;
 
+import static datawave.webservice.query.exception.DatawaveErrorCode.NO_QUERY_RESULTS_FOUND;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -7,6 +8,7 @@ import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
+import java.io.IOException;
 import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
 import java.util.ArrayList;
@@ -33,6 +35,7 @@ import datawave.microservice.querymetric.BaseQueryMetric.PageMetric;
 import datawave.microservice.querymetric.BaseQueryMetric.Prediction;
 import datawave.webservice.query.exception.BadRequestQueryException;
 import datawave.webservice.query.exception.DatawaveErrorCode;
+import datawave.webservice.query.exception.NoResultsQueryException;
 import io.protostuff.LinkedBuffer;
 import io.protostuff.Message;
 import io.protostuff.ProtostuffIOUtil;
@@ -74,6 +77,14 @@ public class QueryMetricTest {
         queryMetric.setError(e);
         assertEquals("The query contained fields which do not exist in the data dictionary for any specified datatype. test", queryMetric.getErrorMessage());
         assertEquals("400-16", queryMetric.getErrorCode());
+        
+        Exception ioe = new IOException("ioe");
+        Exception nrqe = new NoResultsQueryException(NO_QUERY_RESULTS_FOUND, ioe);
+        Exception rte1 = new RuntimeException("rte1", nrqe);
+        Exception rte2 = new RuntimeException("rte2", rte1);
+        queryMetric.setError(rte2);
+        assertEquals(NO_QUERY_RESULTS_FOUND.toString(), queryMetric.getErrorMessage());
+        assertEquals("204-6", queryMetric.getErrorCode());
         
         queryMetric.setErrorCode("");
         Throwable t = new Throwable("non-datawave error");

--- a/api/src/test/java/datawave/microservice/querymetric/QueryMetricTest.java
+++ b/api/src/test/java/datawave/microservice/querymetric/QueryMetricTest.java
@@ -78,7 +78,7 @@ public class QueryMetricTest {
         Throwable t = new Throwable("non-datawave error");
         queryMetric.setError(t);
         assertEquals("non-datawave error", queryMetric.getErrorMessage());
-        assertEquals("", queryMetric.getErrorCode());
+        assertEquals("500-1", queryMetric.getErrorCode());
     }
     
     @Test


### PR DESCRIPTION
When an exception is thrown and subsequently recorded to metrics, if the exception was not a QueryException, and did not have a QueryException cause, then no error code is written to metrics. 

This PR adds a catch-all error code that is written to metrics when that happens.

Additionally fixes an existing test to expect the correct error code.

Closes [datawave/issues/2486](https://github.com/NationalSecurityAgency/datawave/issues/2486)